### PR TITLE
add check to be sure that file from argv exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 file.json\r\nfile2.json\r\nfile.xlsx
+node_modules

--- a/json2xlsx.js
+++ b/json2xlsx.js
@@ -3,8 +3,15 @@
 var xlsx = require('xlsx'),
     fs = require('fs');
 
-if (process.argv[2])
-  readXLSX(process.argv[2]);
+if (process.argv[2]){
+  try {
+    if (fs.existsSync(path)) {
+      readXLSX(process.argv[2]);
+    }
+  } catch(err) {
+    console.error(`The file "${process.argv[2]}" doesn't exists.`)
+  }
+}
 
 function readXLSX(filename) {
   return require('xlsx').readFile(filename).Sheets;


### PR DESCRIPTION
When used as npm module and your module runs with his own `argv` they are treated as files even if they aren't.
This should solve the problem by doing a check of the filesystem.
If the file exist run as usual, if it doesn't print a console error.

Hope this can be useful, it would help with my projects